### PR TITLE
makeblastdb should parse_seqids

### DIFF
--- a/src/main/scala/blastDB.scala
+++ b/src/main/scala/blastDB.scala
@@ -61,7 +61,7 @@ abstract class GenerateBlastDB(
         optionValues =
           title(dbName) ::
           *[AnyDenotation]
-      ).toSeq
+      ).toSeq ++ Seq("-parse_seqids") // TODO use blast-api after updating
     ) -&-
     LazyTry {
       println("Uploading the DB...")


### PR DESCRIPTION
Without this, we cannot use `-seqid_list` with BLAST.
